### PR TITLE
changed filter by attribute filter options order

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/edit.tsx
@@ -231,12 +231,12 @@ const Edit = ( {
 							className="wc-block-attribute-filter__conditions-toggle"
 						>
 							<ToggleGroupControlOption
-								value="and"
-								label={ __( 'All', 'woocommerce' ) }
-							/>
-							<ToggleGroupControlOption
 								value="or"
 								label={ __( 'Any', 'woocommerce' ) }
+							/>
+							<ToggleGroupControlOption
+								value="and"
+								label={ __( 'All', 'woocommerce' ) }
 							/>
 						</ToggleGroupControl>
 					) }


### PR DESCRIPTION
In filter by attribute, order of the filter conditions "ALL" and "ANY" reversed as requested.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

